### PR TITLE
Destroy animation on unmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,13 @@ export default class Lottie extends React.Component {
     this.setDirection();
   }
 
+  componentWillUnmount() {
+    this.deRegisterEvents(this.props.eventListeners);
+    this.destroy();
+    this.options.animationData = null;
+    this.anim = null;
+  }
+
   setSpeed() {
     this.anim.setSpeed(this.props.speed);
   }


### PR DESCRIPTION
I was seeing heavy JS usage even after unmounting my component, with these changes I'm no longer seeing them. 