### PR TITLE
Keep options passed with a new animation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default class Lottie extends React.Component {
     if (this.options.animationData !== nextProps.options.animationData) {
       this.deRegisterEvents(this.props.eventListeners);
       this.destroy();
-      this.options.animationData = nextProps.options.animationData;
+      this.options = {...this.options, ...nextProps.options};
       this.anim = lottie.loadAnimation(this.options);
       this.registerEvents(nextProps.eventListeners);
     }

--- a/src/stories/TransitionWithOptions.js
+++ b/src/stories/TransitionWithOptions.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import Lottie from '../index';
+import * as animationDataA from './TwitterHeart.json';
+import * as animationDataB from './beating-heart.json';
+
+/**
+ * TransitionWithOptions: demonstrates how you can switch to a
+ * new animation with different options. For example, you can start
+ * with a looped animation and change to one that plays only once
+ * without mounting the component again
+ */
+export default class TransitionWithOptions extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showLoopedAnimation: true,
+    };
+  }
+
+  clickHandler = () => {
+    this.setState({ showLoopedAnimation: !this.state.showLoopedAnimation });
+  };
+
+  render() {
+    const centerStyle = {
+      display: 'block',
+      margin: '20px auto',
+      textAlign: 'center',
+    };
+    const { showLoopedAnimation } = this.state;
+    const animationOptionsWithLoop = {
+      animationData: animationDataA,
+      loop: true,
+    };
+    const animationOptionsWithoutLoop = {
+      animationData: animationDataB,
+      loop: false,
+    };
+
+    return (
+      <div>
+        <Lottie
+          options={showLoopedAnimation ? animationOptionsWithLoop : animationOptionsWithoutLoop}
+          height={400}
+          width={400}
+        />
+        <p style={centerStyle}>This animation is {showLoopedAnimation ? 'looped' : 'not looped'}</p>
+        <button style={centerStyle} onClick={this.clickHandler}>
+          switch
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -3,8 +3,10 @@ import { storiesOf, action } from '@kadira/storybook';
 import LottieControl from './lottie-control';
 import ToggleLike from './toggle-like';
 import TransitionLoop from './TransitionLoop';
+import TransitionWithOptions from './TransitionWithOptions';
 
 storiesOf('Lottie Animation View', module)
   .add('with control', () => <LottieControl />)
   .add('toggle like', () => <ToggleLike />)
-  .add('transitions & loops', () => <TransitionLoop />);
+  .add('transitions & loops', () => <TransitionLoop />)
+  .add('transitions with options', () => <TransitionWithOptions />);


### PR DESCRIPTION
This pr makes it possible to transition to a new animation that has different options. Previously, you would have to mount the component again to do this.

It's a small change but I have added a story that helps explain the update. Feel free to remove the story if you don't think it's necessary.

@chenqingspring, thanks in advance for taking a look!