### PR TITLE
feat(componentDidMount): enable `assetsPath` option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export default class Lottie extends React.Component {
         animationData,
         rendererSettings,
         segments,
+        assetsPath,
       },
       eventListeners,
     } = this.props;
@@ -23,6 +24,7 @@ export default class Lottie extends React.Component {
       segments: segments !== false,
       animationData,
       rendererSettings,
+      assetsPath,
     };
 
     this.anim = lottie.loadAnimation(this.options);


### PR DESCRIPTION
Enable `assetsPath` option to pass-through from props.options to lottie.loadAnimation()

https://github.com/airbnb/lottie-web/wiki/loadAnimation-options#assetspath