### PR TITLE
Remove babel-runtime from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "lottie-web": "^5.1.3"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
It isn't used anywhere