### PR TITLE
feat(index): add subFrame so that enterFrame callback matches ae frames

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ export default class Lottie extends React.Component {
     this.options = { ...this.options, ...options };
 
     this.anim = lottie.loadAnimation(this.options);
+    this.setSubframe();
     this.registerEvents(eventListeners);
   }
 
@@ -38,7 +39,7 @@ export default class Lottie extends React.Component {
     if (this.options.animationData !== nextProps.options.animationData) {
       this.deRegisterEvents(this.props.eventListeners);
       this.destroy();
-      this.options = {...this.options, ...nextProps.options};
+      this.options = { ...this.options, ...nextProps.options };
       this.anim = lottie.loadAnimation(this.options);
       this.registerEvents(nextProps.eventListeners);
     }
@@ -52,7 +53,6 @@ export default class Lottie extends React.Component {
     } else {
       this.play();
     }
-
     this.pause();
     this.setSpeed();
     this.setDirection();
@@ -67,6 +67,10 @@ export default class Lottie extends React.Component {
 
   setSpeed() {
     this.anim.setSpeed(this.props.speed);
+  }
+
+  setSubframe() {
+    this.anim.setSubframe(this.props.isSubframe);
   }
 
   setDirection() {
@@ -185,6 +189,7 @@ Lottie.propTypes = {
   isClickToPauseDisabled: PropTypes.bool,
   title: PropTypes.string,
   style: PropTypes.string,
+  isSubframe: PropTypes.bool,
 };
 
 Lottie.defaultProps = {
@@ -196,4 +201,5 @@ Lottie.defaultProps = {
   ariaLabel: 'animation',
   isClickToPauseDisabled: false,
   title: '',
+  isSubframe: true,
 };


### PR DESCRIPTION
lottie-web supports a setSubframe(bool) method to allow you to request that the enterFrame callback is only called back on the exact afterEffects frame.  I have a usecase where I need to play audio at exactly certain frames from my lottie json, so I need this exact callback match.

This PR adds a property called isSubframe that calls the setSubframe method of the lottie-web animation.

There's a bug with lottie-web where it doesn't 100% respect this property right now, but if I set it false currently and even though it calls a few extra times, it does give an explicit frame by frame callback for each frame so I get what I need.
https://github.com/airbnb/lottie-web/issues/967