### PR TITLE
Remove outdated NPM engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,5 @@
     "babel-runtime": "^6.26.0",
     "lottie-web": "^5.1.3"
   },
-  "main": "dist/index.js",
-  "engines": {
-    "npm": "^3.0.0"
-  }
+  "main": "dist/index.js"
 }


### PR DESCRIPTION
According to issue #87 and my team's comments, there's a problem with the required engine of this package. Removing the engine request should be enough for now but if you want to make the requirement of any version in specific, should be at least node version 8.