### PR TITLE
Removed TitleRole from defaultProps to fix pointer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,6 @@ Lottie.defaultProps = {
   isStopped: false,
   isPaused: false,
   speed: 1,
-  ariaRole: 'button',
   ariaLabel: 'animation',
   isClickToPauseDisabled: false,
   title: '',


### PR DESCRIPTION
I was having this issue when the cursor hovered over the animation it turned into pointer for pausing purposes. In my opinion it's better if this isn't a default props. With this changes you're still allowed to turn into a button if you want to.