### PR TITLE
fix animationData  import in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Import pinjump.json.json as animation data
 ```jsx
 import React from 'react'
 import Lottie from 'react-lottie';
-import * as animationData from './pinjump.json'
+import animationData from './pinjump.json'
 
 export default class LottieControl extends React.Component {
 
@@ -56,7 +56,7 @@ export default class LottieControl extends React.Component {
     const defaultOptions = {
       loop: true,
       autoplay: true, 
-      animationData: animationData,
+      animationData,
       rendererSettings: {
         preserveAspectRatio: 'xMidYMid slice'
       }


### PR DESCRIPTION
The recommended way to import `animationData` does not work and has caused a few issues. See:
- https://github.com/chenqingspring/react-lottie/issues/115
- https://github.com/chenqingspring/vue-lottie/issues/20 (in a different repo, but same issue)

This error in the docs is quite misleading. This quick edit should remove the confusion.