### PR TITLE
peerDependencies : react^17.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "standard-version": "^4.4.0"
   },
   "peerDependencies": {
-    "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.7 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",


### PR DESCRIPTION
We have been using this package for quite a while with react@17.0.2 and it works fine with it. thus extending peerDep for the same since we usually get conflicting peerDep issue
```
 Could not resolve dependency:
npm ERR! peer react@"^0.14.7 || ^15.0.0 || ^16.0.0" from react-lottie@1.2.3
npm ERR! node_modules/react-lottie
npm ERR!   react-lottie@"^1.2.3" from the root project

Found: react@17.0.2
```

Please review, merge and deploy on npm if you find it useful.