### PR TITLE
Moving prop-types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "git-url-parse": "^6.0.1",
     "jsdom": "^9.5.0",
     "mocha": "^5.2.0",
-    "prop-types": "^15.6.1",
     "react": "^15.6.2",
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^15.6.2",
@@ -50,7 +49,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "lottie-web": "^5.1.3"
+    "lottie-web": "^5.1.3",
+    "prop-types": "^15.6.1"
   },
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
Although prop-types is meant to run only on development environments, it still is a package required in production code.

Having prop-types under devDependencies means that whoever wants to use react-lottie will get a module not found error for it. Also the recomendation from prop-types team is to add their package as dependencies not devDependencies. You can see this on "How to Depend on This Package?" section on their npm page https://www.npmjs.com/package/prop-types