### PR TITLE
Use `object` instead of `string` for the `style` prop type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ Lottie.propTypes = {
   ariaLabel: PropTypes.string,
   isClickToPauseDisabled: PropTypes.bool,
   title: PropTypes.string,
-  style: PropTypes.string,
+  style: PropTypes.object,
 };
 
 Lottie.defaultProps = {


### PR DESCRIPTION
In version `1.2.4` a change was introduced to [explicitly type the `style` prop](https://github.com/chenqingspring/react-lottie/compare/v1.2.3...v1.2.4#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R187), however, with the wrong `string` causing a runtime error inconsistent with the types.

This PR changes the type to `object` so is consistent with the type defined in [@types/react-lottie](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-lottie/index.d.ts#L93) which is the right one fixing #159.